### PR TITLE
Make bitcore-message external.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lib/**/*.js"
   ],
   "dependencies": {
-    "jsonld-signatures": "^4.0.0"
+    "jsonld-signatures": "^4.2.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.4.4",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -96,7 +96,13 @@ outputs.forEach(info => {
     },
     externals: {
       jsonld: 'jsonld',
-      'jsonld-signatures': 'jsonld-signatures'
+      'jsonld-signatures': 'jsonld-signatures',
+      'bitcore-message': {
+        amd: 'bitcore-message',
+        commonjs: 'bitcore-message',
+        commonjs2: 'bitcore-message',
+        root: 'bitcoreMessage'
+      }
     }
   };
 


### PR DESCRIPTION
Addresses:

https://github.com/digitalbazaar/ocapld.js/issues/18

so this library does not cause constant warnings about bitcore-lib in the browser this PR makes `bitcore-message` an external dependency. This is the same[ webpack option used in jsonld-signatures](https://github.com/digitalbazaar/jsonld-signatures/blob/be3a10a8abe454a10db452fbdddf18b446015095/webpack.config.js#L93-L99) to get around bitcore-lib's browser problems.