### PR TITLE
Fix inspectCapabilityChain implementation.

### DIFF
--- a/lib/CapabilityDelegation.js
+++ b/lib/CapabilityDelegation.js
@@ -38,11 +38,8 @@ module.exports = class CapabilityDelegation extends ControllerProofPurpose {
    *   the creation of the proof.
    * @param [maxTimestampDelta] {integer} a maximum number of seconds that
    *   the date on the signature can deviate from, defaults to `Infinity`.
-   * @param {function} [inspectCapabilityChain] - An async function used to
-   *  check the capability chain. It can be used to find revocations related
-   *  to any of the capabilities in the chain. The expected return value
-   *  is a Promise that resolves to {valid: true/false, error}. The function
-   *  is sent {capabilityIds} where `capabilityIds` is an array of URLs.
+   * @param {function} [inspectCapabilityChain] - See documentation for
+   *   `utils.verifyCapabilityChain`.
    */
   constructor({
     capabilityChain, verifiedParentCapability,

--- a/lib/CapabilityInvocation.js
+++ b/lib/CapabilityInvocation.js
@@ -38,11 +38,8 @@ module.exports = class CapabilityInvocation extends ControllerProofPurpose {
    *   the creation of the proof.
    * @param [maxTimestampDelta] {integer} a maximum number of seconds that
    *   the date on the signature can deviate from, defaults to `Infinity`.
-   * @param {function} [inspectCapabilityChain] - An async function used to
-   *  check the capability chain. It can be used to find revocations related
-   *  to any of the capabilities in the chain. The expected return value
-   *  is a Promise that resolves to {valid: true/false, error}. The function
-   *  is sent {capabilityIds} where `capabilityIds` is an array of URLs.
+   * @param {function} [inspectCapabilityChain] -  See documentation for
+   *   `utils.verifyCapabilityChain`.
    */
   constructor({
     expectedTarget, expectedRootCapability, inspectCapabilityChain,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -348,6 +348,32 @@ api.validateCapabilityChain = ({capability, capabilityChain}) => {
 };
 
 /**
+ * A capability to inspect. The capability is compacted into the security
+ * context. Only the required fields are shown here, a capability will contain
+ * additional properties.
+ * @typedef {Object} Capability
+ * @property {string} id - The ID of the capability.
+ * @property {string} invoker - The invoker of the capability.
+ * @property {string} [delegator] - The delegator of the capability. The last
+ *   capability in the chain will not have a delegator.
+ */
+
+/**
+ * The capability to inspect.
+ * @typedef {Object} CapabilityChainDetails
+ * @property {Capability[]} capabilityChain - The capabilities in the chain.
+ * @property {string} invocationTarget - A URL that specifies the ID of the
+ *   root capability.
+ */
+
+/**
+ * The result of a capability chain inspection.
+ * @typedef {Object} InspectChainResult
+ * @property {boolean} valid - Is the chain valid.
+ * @property {Error} [error] - When valid is false, a descriptive Error.
+ */
+
+/**
  * Verifies the capability chain, if any, attached to the given capability.
  *
  * Verifying the given capability chain means ensuring that the tail capability
@@ -362,11 +388,12 @@ api.validateCapabilityChain = ({capability, capabilityChain}) => {
  * @param {Object} purposeParameters  - a set of options for validating the
  *          proof purpose.
  * @param {function} documentLoader - a configured jsonld documentLoader.
- * @param {function} [inspectCapabilityChain] - An async function that can
- *          be used to check for revocations related to any of the capabilities
- *          in the chain. The expected return value is a Promise that resolves
- *          to {valid: true/false, error}. The function is
- *          sent {capabilityIds} where `capabilityIds` is an array of URLs.
+ * @param {function}
+ *          [inspectCapabilityChain(CapabilityChainDetails):InspectResult] -
+ *          An async function that can be used to check for revocations
+ *          related to any of the capabilities. The expected return value is
+ *          a Promise. See the documentation for CapabilityChainDetails and
+ *          InspectChainResult above.
  * @param {Object} expansionMap - a configured jsonld expansionMap.
  *
  * @return {Object} {verified, error, verifiedParentCapability}.
@@ -503,6 +530,7 @@ api.verifyCapabilityChain = async ({
     // note that `verifiedParentCapability` will prevent repetitive checking
     // of the same segments of the chain (once a parent is verified, its chain
     // is not checked again when checking its children)
+    const dereferencedCapabilities = [];
     for(let cap of capabilityChain) {
       // Transforms the `capability` into the security context (the native
       // context this code uses) so we can process it cleanly and then
@@ -529,6 +557,7 @@ api.verifyCapabilityChain = async ({
           new Error('Capability delegation proof not verified.');
         return {verified: false, error};
       }
+      dereferencedCapabilities.push(cap);
       verifiedParentCapability = cap;
     }
 
@@ -536,15 +565,14 @@ api.verifyCapabilityChain = async ({
       // the given capability was not included in the proof check, but should
       // be included in inspectCapabilityChain (e.g. revocation check)
       if(excludeGivenCapability) {
-        capabilityChain.push(capability);
+        dereferencedCapabilities.push(capability);
       }
-      const capabilityIds = capabilityChain.map(c => {
-        if(typeof c === 'string') {
-          return c;
-        }
-        return c.id;
+
+      const invocationTarget = api.getTarget(root);
+      const {valid, error} = await inspectCapabilityChain({
+        capabilityChain: dereferencedCapabilities,
+        invocationTarget
       });
-      const {valid, error} = await inspectCapabilityChain({capabilityIds});
       if(!valid) {
         throw error;
       }


### PR DESCRIPTION
It was determined that only passing capability IDs was not adequate.