### PR TITLE
Hierachical test

### DIFF
--- a/lib/CapabilityDelegation.js
+++ b/lib/CapabilityDelegation.js
@@ -125,14 +125,15 @@ module.exports = class CapabilityDelegation extends ControllerProofPurpose {
           {document, documentLoader, expansionMap, proof});
 
         const result = await utils.verifyCapabilityChain({
+          allowHierarchicalDelegation,
           capability: capabilityWithProof,
-          inspectCapabilityChain,
-          excludeGivenCapability: true,
-          purposeParameters,
-          documentLoader,
-          expansionMap,
           currentDate,
+          documentLoader,
+          excludeGivenCapability: true,
+          expansionMap,
+          inspectCapabilityChain,
           maxChainLength,
+          purposeParameters,
         });
         if(!result.verified) {
           throw result.error;

--- a/lib/CapabilityDelegation.js
+++ b/lib/CapabilityDelegation.js
@@ -56,6 +56,21 @@ module.exports = class CapabilityDelegation extends ControllerProofPurpose {
     allowHierarchicalDelegation = false
   } = {}) {
     super({term: 'capabilityDelegation', controller, date, maxTimestampDelta});
+
+    if(capabilityChain) {
+      if(!Array.isArray(capabilityChain)) {
+        throw new TypeError('"capabilityChain" must be an array.');
+      }
+      // ensure that all capabilityChain entries except the last are strings
+      const capabilityChainLengthMinusOne = capabilityChain.length - 1;
+      for(let i = 0; i < capabilityChainLengthMinusOne; ++i) {
+        if(typeof capabilityChain[i] !== 'string') {
+          throw new TypeError('All "capabilityChain" entries except the last ' +
+            'one must be strings.');
+        }
+      }
+    }
+
     this.capabilityChain = capabilityChain;
     this.verifiedParentCapability = verifiedParentCapability;
     this.expectedTarget = expectedTarget;

--- a/lib/CapabilityInvocation.js
+++ b/lib/CapabilityInvocation.js
@@ -44,11 +44,15 @@ module.exports = class CapabilityInvocation extends ControllerProofPurpose {
    *   when determining if a capability has expired.
    * @param [maxChainLength=10] - The maximum length of the capability
    *   delegation chain.
+   * @param [allowHierarchicalDelegation=false] {boolean} - Allow the
+   *   invocationTarget of a delegation chain to be increasingly restrictive
+   *   based on a hierarchical RESTful URL structure.
    */
   constructor({
     expectedTarget, expectedRootCapability, inspectCapabilityChain,
     capability, capabilityAction, expectedAction, currentDate, caveat,
-    suite, controller, date, maxTimestampDelta = Infinity, maxChainLength
+    suite, controller, date, maxTimestampDelta = Infinity, maxChainLength,
+    allowHierarchicalDelegation = false
   } = {}) {
     super({term: 'capabilityInvocation', controller, date, maxTimestampDelta});
     this.expectedTarget = expectedTarget;
@@ -58,6 +62,7 @@ module.exports = class CapabilityInvocation extends ControllerProofPurpose {
     this.expectedAction = expectedAction;
     this.inspectCapabilityChain = inspectCapabilityChain;
     this.maxChainLength = maxChainLength;
+    this.allowHierarchicalDelegation = allowHierarchicalDelegation;
     if(caveat !== undefined) {
       if(!Array.isArray(caveat)) {
         this.caveat = [caveat];
@@ -76,14 +81,15 @@ module.exports = class CapabilityInvocation extends ControllerProofPurpose {
   async validate(proof, {verificationMethod, documentLoader, expansionMap}) {
     try {
       const {
+        allowHierarchicalDelegation,
         caveat,
-        expectedAction,
-        expectedTarget,
-        expectedRootCapability,
         currentDate,
+        expectedAction,
+        expectedRootCapability,
+        expectedTarget,
         inspectCapabilityChain,
-        suite,
         maxChainLength,
+        suite,
       } = this;
 
       if(!this.expectedTarget) {
@@ -110,7 +116,7 @@ module.exports = class CapabilityInvocation extends ControllerProofPurpose {
       // 2. verify the capability delegation chain
       const {verified, error} = await utils.verifyCapabilityChain({
         capability, inspectCapabilityChain, purposeParameters, documentLoader,
-        expansionMap, currentDate, maxChainLength
+        expansionMap, currentDate, maxChainLength, allowHierarchicalDelegation
       });
       if(!verified) {
         throw error;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -410,13 +410,16 @@ api.validateCapabilityChain = ({
  *   when determining if a capability has expired.
  * @param [maxChainLength=10] - The maximum length of the capability delegation
  *   chain.
+ * @param [allowHierarchicalDelegation=false] {boolean} - Allow the
+ *   invocationTarget of a delegation chain to be increasingly restrictive
+ *   based on a hierarchical RESTful URL structure.
  *
  * @return {Object} {verified, error, verifiedParentCapability}.
  */
 api.verifyCapabilityChain = async ({
   capability, inspectCapabilityChain, excludeGivenCapability = false,
   purposeParameters, documentLoader, expansionMap, currentDate = new Date(),
-  maxChainLength
+  maxChainLength, allowHierarchicalDelegation = false
 }) => {
   /* Verification process is:
     1. Fetch capability if only its ID was passed.
@@ -613,6 +616,7 @@ api.verifyCapabilityChain = async ({
       const verifyResult = await jsigs.verify(cap, {
         suite,
         purpose: new CapabilityDelegation({
+          allowHierarchicalDelegation,
           expectedTarget,
           expectedRootCapability,
           capabilityAction,

--- a/tests/test-common.js
+++ b/tests/test-common.js
@@ -3971,16 +3971,16 @@ describe('ocapld.js', () => {
         expect(result).to.exist;
         expect(result.verified).to.be.false;
         result.error.errors.should.have.length(1);
-        result.error.errors[0].errors.should.have.length(1);
-        const [error] = result.error.errors[0].errors;
+        const [error] = result.error.errors;
         error.message.should.include(
           'delegated capability must be equivalent or more restrictive');
       });
-      it.skip('should verify a capability chain with hierachical delegation',
+      it('should verify a capability chain with hierachical delegation ' +
+        'and inspectCapabilityChain',
         async () => {
 
         const rootCapability = {
-          id: 'https://example.com/edvs/357570f6-8df2-4e78-97dc-42260d64e78e',
+          id: 'https://example.com/edvs/83d7e997-d742-4b1a-9033-968f222b9144',
           controller: alice.id(),
         };
         addToLoader({doc: rootCapability});
@@ -4034,7 +4034,6 @@ describe('ocapld.js', () => {
         //   4. Parent capability should point to Carol's capability
         //   5. The invoker should be Diana's ID
 
-        console.log('PPPPPPPP', carolCap.invocationTarget);
         // delegate access to a specific document under carol's capability
         const invocationTarget =
           `${carolCap.invocationTarget}/a-specific-document`;
@@ -4045,8 +4044,6 @@ describe('ocapld.js', () => {
           invocationTarget,
           invoker: diana.id()
         };
-
-        console.log('DIANA DELEGATION', JSON.stringify(dianaCap, null, 2));
 
         //  6. Sign the delegated capability with Carol's delegation key
         //     that was specified as the delegator in Carol's capability
@@ -4060,8 +4057,6 @@ describe('ocapld.js', () => {
             ]
           })
         });
-
-        console.log('DIANA DELEGATION', JSON.stringify(dianaDelCap, null, 2));
 
         const inspectCapabilityChain = async ({
           capabilityChain, capabilityChainMeta, invocationTarget
@@ -4082,11 +4077,10 @@ describe('ocapld.js', () => {
           purpose: new CapabilityDelegation({
             allowHierarchicalDelegation: true,
             suite: new Ed25519Signature2018(),
-            // inspectCapabilityChain,
+            inspectCapabilityChain,
           }),
           documentLoader: testLoader
         });
-        console.log('RRRRRrr', JSON.stringify(result, null, 2));
 
         expect(result).to.exist;
         expect(result.verified).to.be.true;


### PR DESCRIPTION
In additional to adding some tests for hierarchical delegation it also enables the `allowHierarchicalDelegation` flag to be used with `inspectCapabilityChain`.  We need to get this feature/fix in to support issuer use case.